### PR TITLE
Add net utils (dig, ping, dnscheck)

### DIFF
--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -13,7 +13,7 @@ import (
 	"github.com/belak/seabird/mux"
 )
 
-type PastebinPlugin struct {
+type NetToolsPlugin struct {
 	Key string
 }
 
@@ -22,7 +22,7 @@ func init() {
 }
 
 func NewNetToolsPlugin(b *bot.Bot, m *mux.CommandMux) error {
-	p := &PastebinPlugin{}
+	p := &NetToolsPlugin{}
 
 	b.Config("pastebin", p)
 
@@ -35,7 +35,7 @@ func NewNetToolsPlugin(b *bot.Bot, m *mux.CommandMux) error {
 	return nil
 }
 
-func (p *PastebinPlugin) Dig(c *irc.Client, e *irc.Event) {
+func (p *NetToolsPlugin) Dig(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Domain required")
@@ -63,7 +63,7 @@ func (p *PastebinPlugin) Dig(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func (p *PastebinPlugin) Ping(c *irc.Client, e *irc.Event) {
+func (p *NetToolsPlugin) Ping(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Host required")
@@ -86,7 +86,7 @@ func (p *PastebinPlugin) Ping(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func (p *PastebinPlugin) Traceroute(c *irc.Client, e *irc.Event) {
+func (p *NetToolsPlugin) Traceroute(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Host required")
@@ -125,7 +125,7 @@ func (p *PastebinPlugin) Traceroute(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func (p *PastebinPlugin) Whois(c *irc.Client, e *irc.Event) {
+func (p *NetToolsPlugin) Whois(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Domain required")
@@ -164,7 +164,7 @@ func (p *PastebinPlugin) Whois(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func (p *PastebinPlugin) DnsCheck(c *irc.Client, e *irc.Event) {
+func (p *NetToolsPlugin) DnsCheck(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Domain required")

--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -171,6 +171,6 @@ func (p *PastebinPlugin) DnsCheck(c *irc.Client, e *irc.Event) {
 			return
 		}
 
-		c.MentionReply(e, "https://www.whatsmydns.net/#A/" + e.Trailing())
+		c.MentionReply(e, "https://www.whatsmydns.net/#A/"+e.Trailing())
 	}()
 }

--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -13,7 +13,7 @@ import (
 	"github.com/belak/seabird/mux"
 )
 
-type NetToolsPlugin struct {
+type PastebinPlugin struct {
 	Key string
 }
 
@@ -22,7 +22,7 @@ func init() {
 }
 
 func NewNetToolsPlugin(b *bot.Bot, m *mux.CommandMux) error {
-	p := &NetToolsPlugin{}
+	p := &PastebinPlugin{}
 
 	b.Config("pastebin", p)
 
@@ -35,7 +35,7 @@ func NewNetToolsPlugin(b *bot.Bot, m *mux.CommandMux) error {
 	return nil
 }
 
-func (p *NetToolsPlugin) Dig(c *irc.Client, e *irc.Event) {
+func (p *PastebinPlugin) Dig(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Domain required")
@@ -63,7 +63,7 @@ func (p *NetToolsPlugin) Dig(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func (p *NetToolsPlugin) Ping(c *irc.Client, e *irc.Event) {
+func (p *PastebinPlugin) Ping(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Host required")
@@ -86,7 +86,7 @@ func (p *NetToolsPlugin) Ping(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func (p *NetToolsPlugin) Traceroute(c *irc.Client, e *irc.Event) {
+func (p *PastebinPlugin) Traceroute(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Host required")
@@ -99,16 +99,11 @@ func (p *NetToolsPlugin) Traceroute(c *irc.Client, e *irc.Event) {
 			return
 		}
 
-		hc := http.Client{}
-
 		form := url.Values{}
 		form.Add("api_dev_key", p.Key)
 		form.Add("api_option", "paste")
 		form.Add("api_paste_code", string(out))
-		req, err := http.NewRequest("POST", "http://pastebin.com/api/api_post.php", strings.NewReader(form.Encode()))
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-		resp, err := hc.Do(req)
+		resp, err := http.Post("http://pastebin.com/api/api_post.php", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 		if err != nil {
 			c.MentionReply(e, "%s", err)
 			return
@@ -125,7 +120,7 @@ func (p *NetToolsPlugin) Traceroute(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func (p *NetToolsPlugin) Whois(c *irc.Client, e *irc.Event) {
+func (p *PastebinPlugin) Whois(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Domain required")
@@ -138,16 +133,11 @@ func (p *NetToolsPlugin) Whois(c *irc.Client, e *irc.Event) {
 			return
 		}
 
-		hc := http.Client{}
-
 		form := url.Values{}
 		form.Add("api_dev_key", p.Key)
 		form.Add("api_option", "paste")
 		form.Add("api_paste_code", string(out))
-		req, err := http.NewRequest("POST", "http://pastebin.com/api/api_post.php", strings.NewReader(form.Encode()))
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-		resp, err := hc.Do(req)
+		resp, err := http.Post("http://pastebin.com/api/api_post.php", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 		if err != nil {
 			c.MentionReply(e, "%s", err)
 			return
@@ -164,7 +154,7 @@ func (p *NetToolsPlugin) Whois(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func (p *NetToolsPlugin) DnsCheck(c *irc.Client, e *irc.Event) {
+func (p *PastebinPlugin) DnsCheck(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Domain required")

--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -76,8 +76,13 @@ func (p *PastebinPlugin) Ping(c *irc.Client, e *irc.Event) {
 			return
 		}
 
-		result := strings.Split(string(out), "\n")[1]
-		c.MentionReply(e, result)
+		arr := strings.Split(string(out), "\n")
+		if len(arr) < 2 {
+			c.MentionReply(e, "Error retrieving ping results")
+			return
+		}
+
+		c.MentionReply(e, arr[1])
 	}()
 }
 

--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -1,0 +1,62 @@
+package plugins
+
+import (
+	"net"
+	"os/exec"
+	"strings"
+
+	"github.com/belak/irc"
+	"github.com/belak/seabird/bot"
+	"github.com/belak/seabird/mux"
+)
+
+func init() {
+	bot.RegisterPlugin("net_tools", NewNetToolsPlugin)
+}
+
+func NewNetToolsPlugin(m *mux.CommandMux) error {
+	m.Event("dig", Dig)
+	m.Event("ping", Ping)
+	m.Event("dnscheck", DnsCheck)
+
+	return nil
+}
+
+func Dig(c *irc.Client, e *irc.Event) {
+	if e.Trailing() == "" {
+		c.MentionReply(e, "Domain required")
+		return
+	}
+
+	addrs, err := net.LookupHost(e.Trailing())
+	if err != nil {
+		c.MentionReply(e, err.Error())
+	}
+
+	c.MentionReply(e, addrs[0])
+}
+
+func Ping(c *irc.Client, e *irc.Event) {
+	if e.Trailing() == "" {
+		c.MentionReply(e, "Host required")
+		return
+	}
+
+	out, err := exec.Command("ping", "-c1", e.Trailing()).Output()
+	if err != nil {
+		c.MentionReply(e, err.Error())
+		return
+	}
+
+	result := strings.Split(string(out), "\n")[1]
+	c.MentionReply(e, result)
+}
+
+func DnsCheck(c *irc.Client, e *irc.Event) {
+	if e.Trailing() == "" {
+		c.MentionReply(e, "Domain required")
+		return
+	}
+
+	c.MentionReply(e, "https://www.whatsmydns.net/#A/" + e.Trailing())
+}

--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -44,10 +44,22 @@ func (p *PastebinPlugin) Dig(c *irc.Client, e *irc.Event) {
 
 		addrs, err := net.LookupHost(e.Trailing())
 		if err != nil {
-			c.MentionReply(e, err.Error())
+			c.MentionReply(e, "%s", err)
+			return
+		}
+
+		if len(addrs) == 0 {
+			c.MentionReply(e, "No results found")
+			return
 		}
 
 		c.MentionReply(e, addrs[0])
+
+		if len(addrs) > 1 {
+			for _, addr := range addrs[1:] {
+				c.Writef("NOTICE %s :%s", e.Identity.Nick, addr)
+			}
+		}
 	}()
 }
 
@@ -60,7 +72,7 @@ func (p *PastebinPlugin) Ping(c *irc.Client, e *irc.Event) {
 
 		out, err := exec.Command("ping", "-c1", e.Trailing()).Output()
 		if err != nil {
-			c.MentionReply(e, err.Error())
+			c.MentionReply(e, "%s", err)
 			return
 		}
 
@@ -78,7 +90,7 @@ func (p *PastebinPlugin) Traceroute(c *irc.Client, e *irc.Event) {
 
 		out, err := exec.Command("traceroute", e.Trailing()).Output()
 		if err != nil {
-			c.MentionReply(e, err.Error())
+			c.MentionReply(e, "%s", err)
 			return
 		}
 
@@ -117,7 +129,7 @@ func (p *PastebinPlugin) Whois(c *irc.Client, e *irc.Event) {
 
 		out, err := exec.Command("whois", e.Trailing()).Output()
 		if err != nil {
-			c.MentionReply(e, err.Error())
+			c.MentionReply(e, "%s", err)
 			return
 		}
 

--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -1,7 +1,10 @@
 package plugins
 
 import (
+	"io/ioutil"
 	"net"
+	"net/http"
+	"net/url"
 	"os/exec"
 	"strings"
 
@@ -10,19 +13,29 @@ import (
 	"github.com/belak/seabird/mux"
 )
 
+type PastebinPlugin struct {
+	Key string
+}
+
 func init() {
 	bot.RegisterPlugin("net_tools", NewNetToolsPlugin)
 }
 
-func NewNetToolsPlugin(m *mux.CommandMux) error {
-	m.Event("dig", Dig)
-	m.Event("ping", Ping)
-	m.Event("dnscheck", DnsCheck)
+func NewNetToolsPlugin(b *bot.Bot, m *mux.CommandMux) error {
+	p := &PastebinPlugin{}
+
+	b.Config("pastebin", p)
+
+	m.Event("dig", p.Dig)
+	m.Event("ping", p.Ping)
+	m.Event("traceroute", p.Traceroute)
+	m.Event("whois", p.Whois)
+	m.Event("dnscheck", p.DnsCheck)
 
 	return nil
 }
 
-func Dig(c *irc.Client, e *irc.Event) {
+func (p *PastebinPlugin) Dig(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Domain required")
@@ -38,7 +51,7 @@ func Dig(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func Ping(c *irc.Client, e *irc.Event) {
+func (p *PastebinPlugin) Ping(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Host required")
@@ -56,7 +69,85 @@ func Ping(c *irc.Client, e *irc.Event) {
 	}()
 }
 
-func DnsCheck(c *irc.Client, e *irc.Event) {
+func (p *PastebinPlugin) Traceroute(c *irc.Client, e *irc.Event) {
+	go func() {
+		if e.Trailing() == "" {
+			c.MentionReply(e, "Host required")
+			return
+		}
+
+		out, err := exec.Command("traceroute", e.Trailing()).Output()
+		if err != nil {
+			c.MentionReply(e, err.Error())
+			return
+		}
+
+		hc := http.Client{}
+
+		form := url.Values{}
+		form.Add("api_dev_key", p.Key)
+		form.Add("api_option", "paste")
+		form.Add("api_paste_code", string(out))
+		req, err := http.NewRequest("POST", "http://pastebin.com/api/api_post.php", strings.NewReader(form.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := hc.Do(req)
+		if err != nil {
+			c.MentionReply(e, "%s", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			c.MentionReply(e, "%s", err)
+			return
+		}
+
+		c.MentionReply(e, "%s", body)
+	}()
+}
+
+func (p *PastebinPlugin) Whois(c *irc.Client, e *irc.Event) {
+	go func() {
+		if e.Trailing() == "" {
+			c.MentionReply(e, "Domain required")
+			return
+		}
+
+		out, err := exec.Command("whois", e.Trailing()).Output()
+		if err != nil {
+			c.MentionReply(e, err.Error())
+			return
+		}
+
+		hc := http.Client{}
+
+		form := url.Values{}
+		form.Add("api_dev_key", p.Key)
+		form.Add("api_option", "paste")
+		form.Add("api_paste_code", string(out))
+		req, err := http.NewRequest("POST", "http://pastebin.com/api/api_post.php", strings.NewReader(form.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := hc.Do(req)
+		if err != nil {
+			c.MentionReply(e, "%s", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			c.MentionReply(e, "%s", err)
+			return
+		}
+
+		c.MentionReply(e, "%s", body)
+	}()
+}
+
+func (p *PastebinPlugin) DnsCheck(c *irc.Client, e *irc.Event) {
 	go func() {
 		if e.Trailing() == "" {
 			c.MentionReply(e, "Domain required")

--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -23,40 +23,46 @@ func NewNetToolsPlugin(m *mux.CommandMux) error {
 }
 
 func Dig(c *irc.Client, e *irc.Event) {
-	if e.Trailing() == "" {
-		c.MentionReply(e, "Domain required")
-		return
-	}
+	go func() {
+		if e.Trailing() == "" {
+			c.MentionReply(e, "Domain required")
+			return
+		}
 
-	addrs, err := net.LookupHost(e.Trailing())
-	if err != nil {
-		c.MentionReply(e, err.Error())
-	}
+		addrs, err := net.LookupHost(e.Trailing())
+		if err != nil {
+			c.MentionReply(e, err.Error())
+		}
 
-	c.MentionReply(e, addrs[0])
+		c.MentionReply(e, addrs[0])
+	}()
 }
 
 func Ping(c *irc.Client, e *irc.Event) {
-	if e.Trailing() == "" {
-		c.MentionReply(e, "Host required")
-		return
-	}
+	go func() {
+		if e.Trailing() == "" {
+			c.MentionReply(e, "Host required")
+			return
+		}
 
-	out, err := exec.Command("ping", "-c1", e.Trailing()).Output()
-	if err != nil {
-		c.MentionReply(e, err.Error())
-		return
-	}
+		out, err := exec.Command("ping", "-c1", e.Trailing()).Output()
+		if err != nil {
+			c.MentionReply(e, err.Error())
+			return
+		}
 
-	result := strings.Split(string(out), "\n")[1]
-	c.MentionReply(e, result)
+		result := strings.Split(string(out), "\n")[1]
+		c.MentionReply(e, result)
+	}()
 }
 
 func DnsCheck(c *irc.Client, e *irc.Event) {
-	if e.Trailing() == "" {
-		c.MentionReply(e, "Domain required")
-		return
-	}
+	go func() {
+		if e.Trailing() == "" {
+			c.MentionReply(e, "Domain required")
+			return
+		}
 
-	c.MentionReply(e, "https://www.whatsmydns.net/#A/" + e.Trailing())
+		c.MentionReply(e, "https://www.whatsmydns.net/#A/" + e.Trailing())
+	}()
 }


### PR DESCRIPTION
Adds dig, ping, and dnscheck.  Traceroute and whois should be added, but might be better served with a webpage of results that are viewable. Perhaps pasting to pastebin and giving that as a result. We'll see. Either way, this references #12.