### PR TITLE
Allow lowercase METAR stations

### DIFF
--- a/plugins/metar.go
+++ b/plugins/metar.go
@@ -36,6 +36,8 @@ func Metar(c *irc.Client, e *irc.Event) {
 }
 
 func metar(code string) string {
+	code = strings.ToUpper(code)
+
 	for _, letter := range code {
 		if !unicode.IsDigit(letter) && !unicode.IsLetter(letter) {
 			return "Not a valid airport code"


### PR DESCRIPTION
Fixes issue #73 where METAR station must be specified in all caps.

Tested changes:
< jgknight> !metar kcmx
< bbqbot> jgknight: KCMX 250053Z AUTO 08008KT 10SM CLR 01/M06 A3001 RMK AO2 SLP180 T00061056

< jgknight> !metar KCMX
< bbqbot> jgknight: KCMX 250053Z AUTO 08008KT 10SM CLR 01/M06 A3001 RMK AO2 SLP180 T00061056
