### PR TITLE
Add YouTube link provider

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -44,3 +44,6 @@ consumersecret    = ""
 accesstoken       = ""
 accesstokensecret = ""
 
+[youtube]
+key               = ""
+

--- a/config.toml
+++ b/config.toml
@@ -44,6 +44,7 @@ consumersecret    = ""
 accesstoken       = ""
 accesstokensecret = ""
 
+# https://developers.google.com/youtube/registering_an_application
 [youtube]
 key               = ""
 

--- a/plugins/linkproviders/youtube.go
+++ b/plugins/linkproviders/youtube.go
@@ -1,0 +1,158 @@
+package linkproviders
+
+import (
+	"net/url"
+	"net/http"
+	"encoding/json"
+	"strings"
+	"fmt"
+
+	"github.com/ChannelMeter/iso8601duration"
+
+	"github.com/belak/seabird/bot"
+	"github.com/belak/seabird/plugins"
+	"github.com/belak/sorcix-irc"
+)
+
+var youtubePrefix = "[YouTube]"
+
+type YoutubeConfig struct {
+	Key string
+}
+
+// https://github.com/ChimeraCoder/gojson
+type Videos struct {
+	Items []struct {
+		ContentDetails struct {
+			Caption         string `json:"caption"`
+			Definition      string `json:"definition"`
+			Dimension       string `json:"dimension"`
+			Duration        string `json:"duration"`
+			LicensedContent bool   `json:"licensedContent"`
+		} `json:"contentDetails"`
+		Snippet struct {
+			CategoryID           string `json:"categoryId"`
+			ChannelID            string `json:"channelId"`
+			ChannelTitle         string `json:"channelTitle"`
+			Description          string `json:"description"`
+			LiveBroadcastContent string `json:"liveBroadcastContent"`
+			Localized            struct {
+				Description string `json:"description"`
+				Title       string `json:"title"`
+			} `json:"localized"`
+			PublishedAt string `json:"publishedAt"`
+			Thumbnails  struct {
+				Default struct {
+					Height int    `json:"height"`
+					URL    string `json:"url"`
+					Width  int    `json:"width"`
+				} `json:"default"`
+				High struct {
+					Height int    `json:"height"`
+					URL    string `json:"url"`
+					Width  int    `json:"width"`
+				} `json:"high"`
+				Medium struct {
+					Height int    `json:"height"`
+					URL    string `json:"url"`
+					Width  int    `json:"width"`
+				} `json:"medium"`
+			} `json:"thumbnails"`
+			Title string `json:"title"`
+		} `json:"snippet"`
+	} `json:"items"`
+}
+
+func NewYoutubeProvider(b *bot.Bot, p *plugins.URLPlugin) error {
+	// Listen for youtube.com and youtu.be URLs
+	p.RegisterProvider("youtube.com", HandleYoutube)
+	p.RegisterProvider("youtu.be", HandleYoutube)
+
+	return nil
+}
+
+func HandleYoutube(b *bot.Bot, m *irc.Message, req *url.URL) bool {
+	// Get API key from seabird config
+	tc := &YoutubeConfig{}
+	err := b.Config("youtube", tc)
+	if err != nil {
+		return false
+	}
+
+	// Get the Video ID from the URL
+	p, _ := url.ParseQuery(req.RawQuery)
+	var id string
+	if len(p["v"]) > 0 {
+		// using full www.youtube.com/?v=bbq
+		id = p["v"][0]
+	}else {
+		// using short youtu.be/bbq
+		path := strings.Split(req.Path, "/")
+		if len(path) < 1{
+			return false
+		}
+		id = path[1]
+	}
+
+	// Get video duration and title
+	time, title := getVideo(id, tc.Key)
+
+	// Invalid video ID or no results
+	if time=="" && title=="" {
+		return false
+	}
+
+	// Send out the IRC message
+	msg := fmt.Sprintf("%s ~ %s", time, title)
+	b.Reply(m, "%s %s", youtubePrefix, msg)
+
+	return true
+}
+
+func getVideo(id string, key string) (time string, title string) {
+	// Build the API call
+	api := fmt.Sprintf("https://www.googleapis.com/youtube/v3/videos?part=contentDetails%%2Csnippet&id=%s&fields=items(contentDetails%%2Csnippet)&key=%s", id, key)
+
+	// Get the YouTube JSON
+	r, _ := http.Get(api)
+	defer r.Body.Close()
+
+	// Decode JSON into the Videos struct
+	var videos Videos
+	dec := json.NewDecoder(r.Body)
+	err := dec.Decode(&videos)
+	if err != nil {
+		return "", ""
+	}
+
+	// Make sure we found a video
+	if len(videos.Items) < 1 {
+		return "", ""
+	}
+
+	v := videos.Items[0]
+
+	// Format the duration
+	d, err := duration.FromString(v.ContentDetails.Duration)
+	if err != nil {
+		return "", ""
+	}
+
+	// always show minutes:seconds even if 00:01 or 1:00
+        dr := fmt.Sprintf("%02d:%02d", d.Minutes, d.Seconds)
+
+        // add Hours if not zero
+        if(d.Hours > 0) {
+                dr = fmt.Sprintf("%02d:%s", d.Hours, dr)
+        }
+        // add Days if not zero. overwrite all other time string
+        if(d.Days > 0){
+                dr = fmt.Sprintf("%02d:%02d:%02d:%02d", d.Days, d.Hours, d.Minutes, d.Seconds)
+        }
+
+	return dr, v.Snippet.Title
+}
+
+
+
+

--- a/plugins/linkproviders/youtube.go
+++ b/plugins/linkproviders/youtube.go
@@ -1,13 +1,13 @@
 package linkproviders
 
 import (
-	"net/url"
-	"net/http"
 	"encoding/json"
-	"strings"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
 
-	"github.com/ChannelMeter/iso8601duration"
+	duration "github.com/ChannelMeter/iso8601duration"
 
 	"github.com/belak/seabird/bot"
 	"github.com/belak/seabird/plugins"
@@ -85,10 +85,10 @@ func HandleYoutube(b *bot.Bot, m *irc.Message, req *url.URL) bool {
 	if len(p["v"]) > 0 {
 		// using full www.youtube.com/?v=bbq
 		id = p["v"][0]
-	}else {
+	} else {
 		// using short youtu.be/bbq
 		path := strings.Split(req.Path, "/")
-		if len(path) < 1{
+		if len(path) < 1 {
 			return false
 		}
 		id = path[1]
@@ -98,7 +98,7 @@ func HandleYoutube(b *bot.Bot, m *irc.Message, req *url.URL) bool {
 	time, title := getVideo(id, tc.Key)
 
 	// Invalid video ID or no results
-	if time=="" && title=="" {
+	if time == "" && title == "" {
 		return false
 	}
 
@@ -132,27 +132,22 @@ func getVideo(id string, key string) (time string, title string) {
 
 	v := videos.Items[0]
 
-	// Format the duration
+	// Convert duration from ISO8601
 	d, err := duration.FromString(v.ContentDetails.Duration)
 	if err != nil {
 		return "", ""
 	}
 
-	// always show minutes:seconds even if 00:01 or 1:00
-        dr := fmt.Sprintf("%02d:%02d", d.Minutes, d.Seconds)
+	var dr string
 
-        // add Hours if not zero
-        if(d.Hours > 0) {
-                dr = fmt.Sprintf("%02d:%s", d.Hours, dr)
-        }
-        // add Days if not zero. overwrite all other time string
-        if(d.Days > 0){
-                dr = fmt.Sprintf("%02d:%02d:%02d:%02d", d.Days, d.Hours, d.Minutes, d.Seconds)
-        }
+	// Print Days and Hours only if they're not 0
+	if d.Days > 0 {
+		dr = fmt.Sprintf("%02d:%02d:%02d:%02d", d.Days, d.Hours, d.Minutes, d.Seconds)
+	} else if d.Hours > 0 {
+		dr = fmt.Sprintf("%02d:%02d:%02d", d.Hours, d.Minutes, d.Seconds)
+	} else {
+		dr = fmt.Sprintf("%02d:%02d", d.Minutes, d.Seconds)
+	}
 
 	return dr, v.Snippet.Title
 }
-
-
-
-

--- a/seabird.go
+++ b/seabird.go
@@ -96,6 +96,11 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	err = linkproviders.NewYoutubeProvider(b, up)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
 	err = b.Run()
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
This adds a link provider to handle Youtube URLs.  If a youtube.com or youtu.be link are received, this will generate a reply with the length of the video, and title.  If an invalid response is received from the Youtube API, we will assume an invalid URL was invalid, and not print anything.

Testing done: Posted a valid youtube.com URL, valid youtu.be URL, and an invalid youtube.com URL

12:38 < jgknight> https://www.youtube.com/watch?v=oEejgX1NANE
12:38 < jailbird> [YouTube] 00:17 ~ Super Talented Dog, his mouth movement is not edited (warning language)
12:38 < jgknight> https://www.youtube.com/watch?v=oEejgX1
12:39 < jgknight> https://youtu.be/oEejgX1NANE
12:39 < jailbird> [YouTube] 00:17 ~ Super Talented Dog, his mouth movement is not edited (warning language)

It could probably use some better error handling. Also I chose not to use Google's golang youtube package as it requires the user to setup oauth.  The API key + json is the most simple way to configure the bot.