### PR TITLE
Rewrite plugins to be more flexible

### DIFF
--- a/bot/auth.go
+++ b/bot/auth.go
@@ -1,0 +1,32 @@
+package bot
+
+import (
+	"github.com/belak/sorcix-irc"
+)
+
+// AuthUser is the user returned by an AuthProvider's LookupUser
+// method.
+type AuthUser interface {
+	HasPerm(b *Bot, perm string) bool
+}
+
+// AuthProvider is a special type of plugin which allows for perms to
+// be looked up so plugins can limit access. The default
+// implementation always returns a user object and always returns true
+// for HasPerm.
+type AuthProvider interface {
+	LookupUser(b *Bot, id *irc.Prefix) AuthUser
+}
+
+// Everything below this point is for the default auth implementation
+type nullAuthUser struct{}
+
+func (u *nullAuthUser) HasPerm(b *Bot, perm string) bool {
+	return true
+}
+
+type nullAuthProvider struct{}
+
+func (a *nullAuthProvider) LookupUser(b *Bot, id *irc.Prefix) AuthUser {
+	return &nullAuthUser{}
+}

--- a/bot/handler.go
+++ b/bot/handler.go
@@ -2,20 +2,19 @@ package bot
 
 import "github.com/belak/sorcix-irc"
 
-// Objects implementing the Handler interface can be
-// registered to serve a particular Event.Command or
-// subcommand in the IRC client.
-//
-// HandleEvent should read the data, formulate a response
-// action (if needed) and then return. Returning signals
-// that the Handler is done with the current Event and will
-// let the IRC client move on to the next Handler or Event.
-//
-// Note that if there are calls that may block for a long time
-// such as network requests and IO, it may be best to grab the
-// required data and run the response code in a goroutine so
-// the rest of the Client can continue as usual.
+// Handler is an interface representing objects which can be
+// registered to serve a particular Event.Command or subcommand in the
+// IRC client.
 type Handler interface {
+	// HandleEvent should read the data, formulate a response
+	// action (if needed) and then return. Returning signals
+	// that the Handler is done with the current Event and will
+	// let the IRC client move on to the next Handler or Event.
+	//
+	// Note that if there are calls that may block for a long time
+	// such as network requests and IO, it may be best to grab the
+	// required data and run the response code in a goroutine so
+	// the rest of the Client can continue as usual.
 	HandleEvent(b *Bot, m *irc.Message)
 }
 

--- a/bot/plugin.go
+++ b/bot/plugin.go
@@ -1,8 +1,31 @@
 package bot
 
-// A plugin is fairly simple in that it only needs to have a method that will
-// register itself with the muxes inside the bot that it needs, however the
-// actual plugin can be as simple or as complex as needed.
-type Plugin interface {
-	Register(b *Bot) error
+import (
+	"fmt"
+	"log"
+)
+
+func init() {
+	plugins = make(map[string]PluginFactory)
+}
+
+var plugins map[string]PluginFactory
+
+// Plugin can be any type. It is unfortunate we have to use an empty
+// interface here, but in order to allow the user to store whatever
+// they want this needs to be the case.
+type Plugin interface{}
+
+// PluginFactory is what actually gets registered as a Plugin. It
+// takes a bot and returns the plugin (or nil) and an error.
+type PluginFactory func(b *Bot) (Plugin, error)
+
+// RegisterPlugin registers a PluginFactory for a given name.
+func RegisterPlugin(name string, factory PluginFactory) error {
+	if _, ok := plugins[name]; ok {
+		log.Fatalln(fmt.Sprintf("Plugin %s is already registered", name))
+	}
+
+	plugins[name] = factory
+	return nil
 }

--- a/plugins/chance.go
+++ b/plugins/chance.go
@@ -8,6 +8,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("chance", NewChancePlugin)
+}
+
 var coinNames = []string{
 	"heads",
 	"tails",
@@ -18,14 +22,12 @@ type ChancePlugin struct {
 	rouletteShotsLeft map[string]int
 }
 
-func NewChancePlugin() bot.Plugin {
-	return &ChancePlugin{
+func NewChancePlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &ChancePlugin{
 		6,
 		make(map[string]int),
 	}
-}
 
-func (p *ChancePlugin) Register(b *bot.Bot) error {
 	b.CommandMux.Event("roulette", p.Roulette, &bot.HelpInfo{
 		Description: "Click... click... BANG!",
 	})
@@ -34,7 +36,7 @@ func (p *ChancePlugin) Register(b *bot.Bot) error {
 		"Guess the coin flip. If you guess wrong, you're out!",
 	})
 
-	return nil
+	return p, nil
 }
 
 func (p *ChancePlugin) Roulette(b *bot.Bot, m *irc.Message) {

--- a/plugins/dice.go
+++ b/plugins/dice.go
@@ -11,17 +11,18 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("dice", NewDicePlugin)
+}
+
 var diceRe = regexp.MustCompile(`(?:^|\b)(\d*)d(\d+)\b`)
 
 type DicePlugin struct{}
 
-func NewDicePlugin() bot.Plugin {
-	return &DicePlugin{}
-}
-
-func (p *DicePlugin) Register(b *bot.Bot) error {
+func NewDicePlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &DicePlugin{}
 	b.MentionMux.Event(p.Dice)
-	return nil
+	return p, nil
 }
 
 func (p *DicePlugin) Dice(b *bot.Bot, m *irc.Message) {

--- a/plugins/expr.go
+++ b/plugins/expr.go
@@ -7,18 +7,21 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
-type MathPlugin struct{}
-
-func NewMathPlugin() bot.Plugin {
-	return &MathPlugin{}
+func init() {
+	bot.RegisterPlugin("math", NewMathPlugin)
 }
 
-func (p *MathPlugin) Register(b *bot.Bot) error {
+type MathPlugin struct{}
+
+func NewMathPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &MathPlugin{}
+
 	b.CommandMux.Event("math", p.Expr, &bot.HelpInfo{
 		"<expr>",
 		"Math. Like calculators and stuff. Bug somebody if you don't know how to math.",
 	})
-	return nil
+
+	return p, nil
 }
 
 func (p *MathPlugin) Expr(b *bot.Bot, m *irc.Message) {

--- a/plugins/google.go
+++ b/plugins/google.go
@@ -10,6 +10,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("google", NewGooglePlugin)
+}
+
 type GooglePlugin struct{}
 
 type GoogleResponse struct {
@@ -22,11 +26,9 @@ type GoogleResponse struct {
 	ResponseStatus int `json:"responseStatus"`
 }
 
-func NewGooglePlugin() bot.Plugin {
-	return &GooglePlugin{}
-}
+func NewGooglePlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &GooglePlugin{}
 
-func (p *GooglePlugin) Register(b *bot.Bot) error {
 	b.CommandMux.Event("g", Web, &bot.HelpInfo{
 		"<query>",
 		"Retrieves top Google web search result for given query",
@@ -36,7 +38,7 @@ func (p *GooglePlugin) Register(b *bot.Bot) error {
 		"Retrieves top Google images search result for given query",
 	})
 
-	return nil
+	return p, nil
 }
 
 func Web(b *bot.Bot, m *irc.Message) {

--- a/plugins/issues.go
+++ b/plugins/issues.go
@@ -9,6 +9,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("issues", NewIssuesPlugin)
+}
+
 type IssueResult struct {
 	Url string `json:"html_url"`
 }
@@ -17,11 +21,8 @@ type IssuesPlugin struct {
 	Token string
 }
 
-func NewIssuesPlugin() bot.Plugin {
-	return &IssuesPlugin{}
-}
-
-func (p *IssuesPlugin) Register(b *bot.Bot) error {
+func NewIssuesPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &IssuesPlugin{}
 	b.Config("github", p)
 
 	b.CommandMux.Event("issue", p.CreateIssue, &bot.HelpInfo{
@@ -29,7 +30,7 @@ func (p *IssuesPlugin) Register(b *bot.Bot) error {
 		"Creates a new issue for seabird. Be nice. Abuse this and it will be removed.",
 	})
 
-	return nil
+	return p, nil
 }
 
 func (p *IssuesPlugin) CreateIssue(b *bot.Bot, m *irc.Message) {

--- a/plugins/linkproviders/bitbucket.go
+++ b/plugins/linkproviders/bitbucket.go
@@ -13,6 +13,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("url/bitbucket", NewBitbucketProvider)
+}
+
 type BitbucketUser struct {
 	Username    string `json:"username"`
 	DisplayName string `json:"display_name"`
@@ -52,9 +56,13 @@ var bitbucketIssueRegex = regexp.MustCompile(`^/([^/]+)/([^/]+)/issue/([^/]+)/[^
 var bitbucketPullRegex = regexp.MustCompile(`^/([^/]+)/([^/]+)/pull-request/([^/]+)/.*$`)
 var bitbucketPrefix = "[Bitbucket]"
 
-func NewBitbucketProvider(p *plugins.URLPlugin) error {
+func NewBitbucketProvider(b *bot.Bot) (bot.Plugin, error) {
+	// Ensure that the url plugin is loaded
+	b.LoadPlugin("url")
+	p := b.Plugins["url"].(*plugins.URLPlugin)
+
 	p.RegisterProvider("bitbucket.org", HandleBitbucket)
-	return nil
+	return nil, nil
 }
 
 func HandleBitbucket(b *bot.Bot, m *irc.Message, url *url.URL) bool {

--- a/plugins/linkproviders/reddit.go
+++ b/plugins/linkproviders/reddit.go
@@ -10,6 +10,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("url/reddit", NewRedditProvider)
+}
+
 type RedditUser struct {
 	Data struct {
 		Name         string `json:"name"`
@@ -47,9 +51,13 @@ var redditCommentRegex = regexp.MustCompile(`^/r/[^/]+/comments/([^/]+)/.*$`)
 var redditSubRegex = regexp.MustCompile(`^/r/([^/]+)/?.*$`)
 var redditPrefix = "[Reddit]"
 
-func NewRedditProvider(p *plugins.URLPlugin) error {
+func NewRedditProvider(b *bot.Bot) (bot.Plugin, error) {
+	// Ensure that the url plugin is loaded
+	b.LoadPlugin("url")
+	p := b.Plugins["url"].(*plugins.URLPlugin)
+
 	p.RegisterProvider("reddit.com", HandleReddit)
-	return nil
+	return nil, nil
 }
 
 func HandleReddit(b *bot.Bot, m *irc.Message, u *url.URL) bool {

--- a/plugins/linkproviders/twitter.go
+++ b/plugins/linkproviders/twitter.go
@@ -12,6 +12,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("url/twitter", NewTwitterProvider)
+}
+
 type TwitterConfig struct {
 	ConsumerKey       string
 	ConsumerSecret    string
@@ -27,13 +31,17 @@ var twitterStatusRegex = regexp.MustCompile(`^/.*?/status/(.+)$`)
 var twitterUserRegex = regexp.MustCompile(`^/([^/]+)$`)
 var twitterPrefix = "[Twitter]"
 
-func NewTwitterProvider(b *bot.Bot, p *plugins.URLPlugin) error {
+func NewTwitterProvider(b *bot.Bot) (bot.Plugin, error) {
+	// Ensure that the url plugin is loaded
+	b.LoadPlugin("url")
+	p := b.Plugins["url"].(*plugins.URLPlugin)
+
 	t := &TwitterProvider{}
 
 	tc := &TwitterConfig{}
 	err := b.Config("twitter", tc)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	anaconda.SetConsumerKey(tc.ConsumerKey)
@@ -42,7 +50,7 @@ func NewTwitterProvider(b *bot.Bot, p *plugins.URLPlugin) error {
 
 	p.RegisterProvider("twitter.com", t.Handle)
 
-	return nil
+	return nil, nil
 }
 
 func (t *TwitterProvider) Handle(b *bot.Bot, m *irc.Message, u *url.URL) bool {

--- a/plugins/linkproviders/xkcd.go
+++ b/plugins/linkproviders/xkcd.go
@@ -15,16 +15,24 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("url/xkcd", NewXKCDProvider)
+}
+
 var xkcdRegex = regexp.MustCompile(`^/([^/]+)$`)
 var xkcdPrefix = "[XKCD]"
 
 type XKCDProvider struct{}
 
-func NewXKCDProvider(p *plugins.URLPlugin) error {
+func NewXKCDProvider(b *bot.Bot) (bot.Plugin, error) {
+	// Ensure that the url plugin is loaded
+	b.LoadPlugin("url")
+	p := b.Plugins["url"].(*plugins.URLPlugin)
+
 	t := &XKCDProvider{}
 	p.RegisterProvider("xkcd.com", t.Handle)
 
-	return nil
+	return nil, nil
 }
 
 func (p *XKCDProvider) Handle(b *bot.Bot, m *irc.Message, url *url.URL) bool {

--- a/plugins/linkproviders/youtube.go
+++ b/plugins/linkproviders/youtube.go
@@ -14,6 +14,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("url/youtube", NewYoutubeProvider)
+}
+
 var youtubePrefix = "[YouTube]"
 
 type YoutubeConfig struct {
@@ -63,12 +67,16 @@ type Videos struct {
 	} `json:"items"`
 }
 
-func NewYoutubeProvider(b *bot.Bot, p *plugins.URLPlugin) error {
+func NewYoutubeProvider(b *bot.Bot) (bot.Plugin, error) {
+	// Ensure that the url plugin is loaded
+	b.LoadPlugin("url")
+	p := b.Plugins["url"].(*plugins.URLPlugin)
+
 	// Listen for youtube.com and youtu.be URLs
 	p.RegisterProvider("youtube.com", HandleYoutube)
 	p.RegisterProvider("youtu.be", HandleYoutube)
 
-	return nil
+	return nil, nil
 }
 
 func HandleYoutube(b *bot.Bot, m *irc.Message, req *url.URL) bool {

--- a/plugins/mentions.go
+++ b/plugins/mentions.go
@@ -5,15 +5,16 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
-type MentionsPlugin struct{}
-
-func NewMentionsPlugin() bot.Plugin {
-	return &MentionsPlugin{}
+func init() {
+	bot.RegisterPlugin("mentions", NewMentionsPlugin)
 }
 
-func (p *MentionsPlugin) Register(b *bot.Bot) error {
+type MentionsPlugin struct{}
+
+func NewMentionsPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &MentionsPlugin{}
 	b.MentionMux.Event(Mentions)
-	return nil
+	return p, nil
 }
 
 func Mentions(b *bot.Bot, m *irc.Message) {

--- a/plugins/metar.go
+++ b/plugins/metar.go
@@ -11,19 +11,21 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
-type MetarPlugin struct{}
-
-func NewMetarPlugin() bot.Plugin {
-	return &MetarPlugin{}
+func init() {
+	bot.RegisterPlugin("metar", NewMetarPlugin)
 }
 
-func (p *MetarPlugin) Register(b *bot.Bot) error {
+type MetarPlugin struct{}
+
+func NewMetarPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &MetarPlugin{}
+
 	b.CommandMux.Event("metar", Metar, &bot.HelpInfo{
 		"<station>",
 		"Gives METAR report for given airport code",
 	})
 
-	return nil
+	return p, nil
 }
 
 func Metar(b *bot.Bot, m *irc.Message) {

--- a/plugins/net_tools.go
+++ b/plugins/net_tools.go
@@ -12,15 +12,17 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("nettools", NewNetToolsPlugin)
+}
+
 type NetToolsPlugin struct {
 	Key string
 }
 
-func NewNetToolsPlugin() bot.Plugin {
-	return &NetToolsPlugin{}
-}
+func NewNetToolsPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &NetToolsPlugin{}
 
-func (p *NetToolsPlugin) Register(b *bot.Bot) error {
 	b.Config("net_tools", p)
 
 	b.CommandMux.Event("rdns", p.RDNS, &bot.HelpInfo{
@@ -48,7 +50,7 @@ func (p *NetToolsPlugin) Register(b *bot.Bot) error {
 		"Returns DNSCheck URL for domain",
 	})
 
-	return nil
+	return p, nil
 }
 
 func (p *NetToolsPlugin) RDNS(b *bot.Bot, m *irc.Message) {

--- a/plugins/tiny.go
+++ b/plugins/tiny.go
@@ -9,6 +9,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("tiny", NewTinyPlugin)
+}
+
 type ShortenResult struct {
 	Kind    string `json:"kind"`
 	Id      string `json:"id"`
@@ -17,17 +21,15 @@ type ShortenResult struct {
 
 type TinyPlugin struct{}
 
-func NewTinyPlugin() bot.Plugin {
-	return &TinyPlugin{}
-}
+func NewTinyPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &TinyPlugin{}
 
-func (p *TinyPlugin) Register(b *bot.Bot) error {
 	b.CommandMux.Event("tiny", Shorten, &bot.HelpInfo{
 		"<url>",
 		"Shortens given URL",
 	})
 
-	return nil
+	return p, nil
 }
 
 func Shorten(b *bot.Bot, m *irc.Message) {

--- a/plugins/tvdb.go
+++ b/plugins/tvdb.go
@@ -14,6 +14,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("tvdb", NewTVDBPlugin)
+}
+
 type TVDBPlugin struct {
 	Key string
 }
@@ -44,11 +48,9 @@ type TVDBZipResponse struct {
 	} `xml:"Series"`
 }
 
-func NewTVDBPlugin() bot.Plugin {
-	return &TVDBPlugin{}
-}
+func NewTVDBPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &TVDBPlugin{}
 
-func (p *TVDBPlugin) Register(b *bot.Bot) error {
 	b.Config("tvdb", p)
 
 	b.CommandMux.Event("tvdb", p.Search, &bot.HelpInfo{
@@ -60,7 +62,7 @@ func (p *TVDBPlugin) Register(b *bot.Bot) error {
 		"Gives expanded info on TVDB series using TVDB ID",
 	})
 
-	return nil
+	return p, nil
 }
 
 func (p *TVDBPlugin) Search(b *bot.Bot, m *irc.Message) {

--- a/plugins/url.go
+++ b/plugins/url.go
@@ -17,6 +17,10 @@ import (
 	"github.com/belak/sorcix-irc"
 )
 
+func init() {
+	bot.RegisterPlugin("url", NewURLPlugin)
+}
+
 // NOTE: This isn't perfect in any sense of the word, but it's pretty close
 // and I don't know if it's worth the time to make it better.
 var urlRegex = regexp.MustCompile(`https?://[^ ]+`)
@@ -36,13 +40,11 @@ type URLPlugin struct {
 
 type LinkProvider func(b *bot.Bot, m *irc.Message, url *url.URL) bool
 
-func NewURLPlugin() bot.Plugin {
-	return &URLPlugin{
+func NewURLPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &URLPlugin{
 		providers: make(map[string][]LinkProvider),
 	}
-}
 
-func (p *URLPlugin) Register(b *bot.Bot) error {
 	b.BasicMux.Event("PRIVMSG", p.URLTitle)
 
 	b.CommandMux.Event("down", IsItDown, &bot.HelpInfo{
@@ -50,7 +52,7 @@ func (p *URLPlugin) Register(b *bot.Bot) error {
 		"Checks if given website is down",
 	})
 
-	return nil
+	return p, nil
 }
 
 func (p *URLPlugin) RegisterProvider(domain string, f LinkProvider) error {

--- a/plugins/wikipedia.go
+++ b/plugins/wikipedia.go
@@ -13,6 +13,10 @@ import (
 	"github.com/yhat/scrape"
 )
 
+func init() {
+	bot.RegisterPlugin("wiki", NewWikiPlugin)
+}
+
 type WikiResponse struct {
 	Parse struct {
 		Title string `json:"title"`
@@ -24,17 +28,15 @@ type WikiResponse struct {
 
 type WikiPlugin struct{}
 
-func NewWikiPlugin() bot.Plugin {
-	return &WikiPlugin{}
-}
+func NewWikiPlugin(b *bot.Bot) (bot.Plugin, error) {
+	p := &WikiPlugin{}
 
-func (p *WikiPlugin) Register(b *bot.Bot) error {
 	b.CommandMux.Event("wiki", Wiki, &bot.HelpInfo{
 		"<topic>",
 		"Retrieves first section from most relevant Wikipedia article to given topic",
 	})
 
-	return nil
+	return p, nil
 }
 
 func transformQuery(query string) string {

--- a/seabird.go
+++ b/seabird.go
@@ -5,22 +5,16 @@ import (
 	"os"
 
 	"github.com/belak/seabird/bot"
-	"github.com/jmoiron/sqlx"
 
 	// Load plugins
 	//_ "github.com/belak/seabird/auth"
-	"github.com/belak/seabird/plugins"
-	"github.com/belak/seabird/plugins/linkproviders"
+	_ "github.com/belak/seabird/plugins"
+	_ "github.com/belak/seabird/plugins/linkproviders"
 
 	// Load DB drivers
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 )
-
-type DBConfig struct {
-	Driver     string
-	DataSource string
-}
 
 func main() {
 	conf := os.Getenv("SEABIRD_CONFIG")
@@ -34,78 +28,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// We only actually do something if there hasn't been an error yet.
-	registerPlugin := func(p bot.Plugin) bot.Plugin {
-		if err == nil {
-			err = b.RegisterPlugin(p)
-		}
-		return p
-	}
-
-	dbc := &DBConfig{}
-	err = b.Config("db", dbc)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	db, err := sqlx.Connect(dbc.Driver, dbc.DataSource)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	registerPlugin(plugins.NewChancePlugin())
-	//registerPlugin(plugins.NewCTCPPlugin())
-	registerPlugin(plugins.NewDicePlugin())
-	registerPlugin(plugins.NewMathPlugin())
-	registerPlugin(plugins.NewForecastPlugin(db))
-	registerPlugin(plugins.NewIssuesPlugin())
-	registerPlugin(plugins.NewGooglePlugin())
-	registerPlugin(plugins.NewKarmaPlugin(db))
-	registerPlugin(plugins.NewLastSeenPlugin(db))
-	registerPlugin(plugins.NewMentionsPlugin())
-	registerPlugin(plugins.NewMetarPlugin())
-	registerPlugin(plugins.NewNetToolsPlugin())
-	//registerPlugin(plugins.NewNickTrackerPlugin())
-	registerPlugin(plugins.NewTinyPlugin())
-	registerPlugin(plugins.NewTVDBPlugin())
-	registerPlugin(plugins.NewWikiPlugin())
-
-	up := registerPlugin(plugins.NewURLPlugin()).(*plugins.URLPlugin)
-
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	err = linkproviders.NewGithubProvider(b, up)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	err = linkproviders.NewTwitterProvider(b, up)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	err = linkproviders.NewRedditProvider(up)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	err = linkproviders.NewBitbucketProvider(up)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	err = linkproviders.NewYoutubeProvider(b, up)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	err = linkproviders.NewXKCDProvider(up)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
+	// Run the bot
 	err = b.Run()
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
This does a number of things.

- [x] Load plugins automatically again (this was removed some time a long while ago)
- [x] Allows for plugins to depend on other plugins by calling `b.LoadPlugin`
- [x] Allow access to plugins through the `bot.Bot.Plugins` map
- [x] Rewrites URL providers to be actual plugins
- [x] Moves the database into the bot object
- [x] Creates an Auth interface
- [x] Creates an extremely basic auth Interface which always returns true
- [x] Adds `bot.Bot.PluginLoaded` or something like that
- [x] Adds in selectively loading plugins
- [x] Detect circular loads

Things that may come later

- [x] Cleans up exported functions (coming in another PR)
- [x] Only returns plugin values when other plugins will actually need to use them (similar to cleaning up exported functions)
- [x] Adds documentation to exported functions (coming in another PR)
- [x] Make DB a plugin (possibly coming later)

Things not being done

- [x] Only stores plugin return value if non-nil